### PR TITLE
update jenkinsxio/builder-base to 0.0.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsxio/builder-base:0.0.10
+FROM jenkinsxio/builder-base:0.0.13
 
 # Maven
 ENV MAVEN_VERSION 3.3.9


### PR DESCRIPTION
[UpdateBot](https://github.com/fabric8io/updatebot) pushed docker dependency: `jenkinsxio/builder-base` to: `0.0.13`